### PR TITLE
Minor Dockerfile changes to make the container more secure.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+spec
+client

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,18 @@
 FROM node:6.10
 MAINTAINER Jay Arella (jarella@scpr.org)
 
-RUN mkdir -p /usr/src/app
+# cache node-modules
+COPY package.json /tmp/package.json
+RUN cd /tmp && npm install
+
+RUN mkdir -p /usr/src/app && cp -a /tmp/node_modules /usr/src/app
 WORKDIR /usr/src/app
-
 COPY . /usr/src/app
-
-RUN npm install
-
 EXPOSE 8080
-CMD [ "npm", "start" ]
+
+# create a non-root user
+RUN groupadd -r nodejs \
+    && useradd -m -r -g nodejs nodejs
+USER nodejs
+
+CMD [ "npm", "run", "server" ]


### PR DESCRIPTION
Since the Dockerfile is for getting the production app running in a container on the server, I made a few changes:

1.) only include the BUILD_DIR and relevant files for serving. No need for the src files.
2.) Cache node_modules layer up at the top so that the only time that the build will need to `npm i` i if package.json ever changes.  Makes builds faster.
3.) I created a 'nodejs' non-root user to execute the app for security. It'll make it slightly harder for someone to break through to another container.